### PR TITLE
add ability to update mapfile wms_timedefault to nearest interval

### DIFF
--- a/geomet_mapfile/util.py
+++ b/geomet_mapfile/util.py
@@ -64,6 +64,17 @@ def remove_prefix(text, prefix):
     return text
 
 
+def get_nearest(items, target):
+    """
+    Utility function to return nearest value to the target. Works on all
+    object types that support comparison, substraction and abs function.
+    :param items: `list` of items to test against
+    :param target: item to test against
+    :returns: closest item to target
+    """
+    return min(items, key=lambda x: abs(x - target))
+
+
 def clean_style(filepath, output_format='json'):
     # TODO: docstring
     with open(filepath, 'r') as f:

--- a/geomet_mapfile/wsgi.py
+++ b/geomet_mapfile/wsgi.py
@@ -306,7 +306,9 @@ def application(env, start_response):
             filepath, url = get_data_path(layer, time, ref_time)
         except TileNotFoundError as err:
             LOGGER.error(err)
-            time_error = 'NoMatch: Date et heure invalides / Invalid date and time'  # noqa
+            time_error = (
+                'NoMatch: Date et heure invalides / Invalid date and time'
+            )
             start_response('200 OK', [('Content-type', 'text/xml')])
             return [SERVICE_EXCEPTION.format(time_error).encode()]
 
@@ -334,9 +336,13 @@ def application(env, start_response):
 
         except ValueError as err:
             LOGGER.error(err)
-            _error = 'NoApplicableCode: Donnée non disponible / Data not available'  # noqa
-            start_response('500 Internal Server Error',
-                           [('Content-type', 'text/xml')])
+            _error = (
+                'NoApplicableCode: Donnée non disponible / Data not available'
+            )
+            start_response(
+                '500 Internal Server Error',
+                [('Content-type', 'text/xml')]
+            )
             return [SERVICE_EXCEPTION.format(_error).encode()]
 
         if request_ == 'GetCapabilities' and lang == 'fr':


### PR DESCRIPTION
When generating a mapfile for data associated to any model run, we now create a list of all possible forecast hour datetimes as a comma-seperate string under the `wms_available_intervals` metadata keyword.

This allows us to update the mapfile's `wms_timedefault` metadata value to the closest available time interval via the command line and potentially elsewhere (via notifications/cron in the future).

The command to update the mapfiles is:
`geomet-mapfile mapfile update` with an option to add an `-l` flag to update a passed layer.

Also includes some minor flake8 fixes.