### PR TITLE
fix broken test_gen_layer

### DIFF
--- a/geomet_mapfile/__init__.py
+++ b/geomet_mapfile/__init__.py
@@ -23,7 +23,7 @@ __version__ = '0.1.dev0'
 import click
 
 from geomet_mapfile.util import utils
-from geomet_mapfile.mapfile import mapfile
+from geomet_mapfile.mapfile import mapfile_
 from geomet_mapfile.store import store
 from geomet_mapfile.wsgi import serve
 
@@ -35,6 +35,6 @@ def cli():
 
 
 cli.add_command(utils)
-cli.add_command(mapfile)
+cli.add_command(mapfile_)
 cli.add_command(store)
 cli.add_command(serve)

--- a/geomet_mapfile/mapfile.py
+++ b/geomet_mapfile/mapfile.py
@@ -662,8 +662,8 @@ def update_mapfile(layer=None):
     return True
 
 
-@click.group()
-def mapfile():
+@click.group('mapfile')
+def mapfile_():
     """mapfile management"""
     pass
 
@@ -696,8 +696,8 @@ def update(ctx, layer):
     update_mapfile(layer)
 
 
-mapfile.add_command(generate)
-mapfile.add_command(update)
+mapfile_.add_command(generate)
+mapfile_.add_command(update)
 
 
 class LayerTimeConfigError(Exception):

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -47,14 +47,17 @@ class Store:
 
     def __init__(self):
         self.data = {
-            'GDPS.ETA_TT_time_extent': '2020-01-14T00:00:00Z/2020-01-24T00:00:00Z/PT3H',  # noqa
-            'GDPS.ETA_TT_model_run_extent': '2020-01-12T00:00:00Z/2020-01-14T00:00:00Z/PT12H',  # noqa
-            'GDPS.ETA_TT_default_model_run': '2020-01-14T00:00:00Z'
+            'geomet-data-registry_GDPS.ETA_TT_time_extent': '2020-01-14T00:00:00Z/2020-01-24T00:00:00Z/PT3H', # noqa
+            'geomet-data-registry_GDPS.ETA_TT_default_time': '2020-01-14T00:00:00Z',  # noqa
+            'geomet-data-registry_GDPS.ETA_TT_model_run_extent': '2020-01-12T00:00:00Z/2020-01-14T00:00:00Z/PT12H',  # noqa
+            'geomet-data-registry_GDPS.ETA_TT_default_model_run': '2020-01-14T00:00:00Z', # noqa
         }
 
-    def get_key(self, key):
+    def get_key(self, key, raw=False):
         try:
-            return self.data[key]
+            if raw:
+                return self.data[key]
+            return self.data[f'geomet-mapfile_{key}']
         except KeyError:
             return None
 
@@ -107,7 +110,7 @@ class GeoMetMapfileTest(unittest.TestCase):
         self.assertTrue(
             result['ows_contactinstructions_fr'] == 'Durant les heures de service')  # noqa
 
-    @patch('geomet_mapfile.plugin.load_plugin', return_value=Store())
+    @patch('geomet_mapfile.mapfile.load_plugin', return_value=Store())
     def test_gen_layer(self, mock_load_plugin):
         """returns a list of mappfile layer objects of given layer"""
 
@@ -121,7 +124,7 @@ class GeoMetMapfileTest(unittest.TestCase):
         result = gen_layer(layer_name, layer_info)
 
         self.assertTrue(result[0]['projection'] ==
-                        ['proj=longlat', 'R=6371229', 'no_defs'])
+                        ['proj=longlat', "lon_wrap=0", 'R=6371229', 'no_defs'])
         self.assertTrue(result[0]['name'] == layer_name)
         self.assertTrue(result[0]['data'] == [''])
         self.assertTrue(result[0]['metadata']['ows_title'] == ows_title)


### PR DESCRIPTION
Fixes the geomet-mapfile tests due to following three errors:

- Collision between `mapfile.py` and  the `@click.group()` named `mapfile` made it so that the `@patch('geomet_mapfile.mapfile.load_plugin')` in `run_tests.py` was trying to access `load_plugin()` in the `click` group which does not exist. Renamed the `click` group to avoid collision.
- `@patch` decorator must point to `load_plugin()` function in module in which it is looked up and not in the module in which it is defined. 
- `raw` argument added to the `RedisStore.get_key()` method needed to be implemented in the mocked `Store` instance used by the tests and store keys changed in accordance.

CC @PhilippeTH (thanks!)