### PR TITLE
fix indent issue when updating wms_timedefault in store

### DIFF
--- a/geomet_mapfile/mapfile.py
+++ b/geomet_mapfile/mapfile.py
@@ -658,10 +658,10 @@ def update_mapfile(layer=None):
                 (key, st.get_key(f'{key}', raw=True))
                 for key in st.list_keys('geomet-mapfile*_layer')
             ]
-    for name, mapfile in mapfiles:
-        LOGGER.debug(f'Updating {name} in store.')
-        updated_mapfile = find_replace_wms_timedefault(name, mapfile)
-        st.set_key(name, updated_mapfile, raw=True)
+        for name, mapfile in mapfiles:
+            LOGGER.debug(f'Updating {name} in store.')
+            updated_mapfile = find_replace_wms_timedefault(name, mapfile)
+            st.set_key(name, updated_mapfile, raw=True)
 
     return True
 


### PR DESCRIPTION
There is a small issue with the indentation level of a `for` loop when updating `wms_timedefault` for mapfiles in store.

This MR brings the indentation level inside the correct `if` condition.