### PR TITLE
Changed gen_layer return value from list of dict to dict

### DIFF
--- a/geomet_mapfile/mapfile.py
+++ b/geomet_mapfile/mapfile.py
@@ -295,8 +295,6 @@ def gen_layer(layer_name, layer_info):
     :returns: list of mappyfile layer objects of layer
     """
 
-    layers = []
-
     LOGGER.debug('Setting up layer configuration')
 
     layer = {}
@@ -455,9 +453,7 @@ def gen_layer(layer_name, layer_info):
 
     layer['metadata'].update(mcf2layer_metadata(mcf_file))
 
-    layers.append(layer)
-
-    return layers
+    return layer
 
 
 def generate_mapfile(layer=None, output='file', use_includes=True):
@@ -498,14 +494,13 @@ def generate_mapfile(layer=None, output='file', use_includes=True):
         mapfile_copy['layers'] = []
 
         try:
-            layers = gen_layer(key, value)
+            lyr = gen_layer(key, value)
         except LayerTimeConfigError:
-            layers = None
+            lyr = None
             time_errors = True
 
-        if layers:
-            for lyr in layers:
-                mapfile_copy['layers'].append(lyr)
+        if lyr:
+            mapfile_copy['layers'].append(lyr)
 
             # TODO: simplify
             if 'outputformats' in value['forecast_model']:


### PR DESCRIPTION
gen_layer was returning a list that only ever contained a single dict, which was then only used by generate_mapfile inside a for loop to take the dict out of the list. I have thus removed the list and made the appropriate changes so gen_layer would return a dict directly and removed the for loop inside generate_mapfile. I have also renamed "layers" to "lyr" since gen_layer only ever returns a single dict. "layer" was already the name used by the input of generate_mapfile, thus "lyr" was used instead.